### PR TITLE
windows fix - docker container stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,14 @@ cd workshop-introduction-to-nosql
   >```
 :warning: *Linux users:*
 
+:📝 Note for *Windows users:*
+  >Start the *studio image* `without a volume`. Remove these 2 lines above `networks` in *studio* (see: `docker-compose.yaml` file) 
+  >```yaml
+  >volumes:
+  >    - "./datastax-studio-config:/var/lib/datastax-studio"
+
+:📝 Note for *Windows users:*
+
 Start containers:
 ```bash
 docker-compose up -d

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
        - dse
      environment:
        DS_LICENSE: accept
+      #  for windows users - start studio image without volumes (remove the below 2 lines)
      volumes:
        - "./datastax-studio-config:/var/lib/datastax-studio"
      networks:


### PR DESCRIPTION
In graph databases section,
problem: On windows the docker container stops in few minutes after starting
solution: remove line no 45 and 46 and start the studio image without volume